### PR TITLE
Fix "API Update Required" notice due to deprecated BuildTarget.iPhone

### DIFF
--- a/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
+++ b/unity/Assets/Editor/URLClient/URLClientPostprocessor.cs
@@ -35,7 +35,7 @@ public class URLClientPostprocessor : Editor
   public static void OnPostprocessBuild(BuildTarget target,
       string pathToBuildProject)
   {
-    if (target != BuildTarget.iPhone)
+    if (target != BuildTarget.iOS)
     {
       return;
     }


### PR DESCRIPTION
The "API Update Required" popup is appearing on import, and `BuildTarget.iPhone` seems to be the cause:

```
Assets/Editor/URLClient/URLClientPostprocessor.cs(38,31): error CS0619: `UnityEditor.BuildTarget.iPhone' is obsolete: `Use iOS instead (UnityUpgradable) -> iOS'
```
